### PR TITLE
Add ngspice normalization/analysis tooling and fixtures

### DIFF
--- a/analysis/tools/ngspice/h5_query.py
+++ b/analysis/tools/ngspice/h5_query.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Compact HDF5 query tool for normalized waveform artifacts.
+
+Subcommands
+-----------
+- list-signals
+- summary
+- head --signal <name> --n <k>
+- range --signal <name> --x0 <val> --x1 <val>
+
+Default output is JSON. Use ``--format text`` for plain text output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+try:
+    import h5py
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(
+        "h5py is required for tools/h5_query.py. Install with: pip install h5py"
+    ) from exc
+
+
+class QueryError(RuntimeError):
+    """Raised for actionable query failures."""
+
+
+@dataclass
+class SignalTable:
+    indep: np.ndarray
+    signals: dict[str, np.ndarray]
+
+
+def _decode_name(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, np.bytes_):
+        return bytes(value).decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _as_1d(dataset: Any) -> np.ndarray:
+    arr = np.asarray(dataset)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    if arr.ndim != 1:
+        raise QueryError(f"Expected 1D dataset but found shape={arr.shape}")
+    return arr
+
+
+def _load_indep(h5: h5py.File) -> np.ndarray:
+    if "indep_var" not in h5:
+        raise QueryError("Missing required dataset: indep_var")
+    indep = _as_1d(h5["indep_var"][...])
+    return indep
+
+
+def _load_signals_from_group(h5: h5py.File, n_points: int) -> dict[str, np.ndarray]:
+    if "signals" not in h5 or not isinstance(h5["signals"], h5py.Group):
+        return {}
+
+    out: dict[str, np.ndarray] = {}
+    sig_group = h5["signals"]
+    for name in sig_group.keys():
+        values = _as_1d(sig_group[name][...])
+        if values.shape[0] != n_points:
+            raise QueryError(
+                f"Signal '{name}' length={values.shape[0]} does not match indep_var length={n_points}"
+            )
+        out[name] = values
+    return out
+
+
+def _load_signals_from_vectors(h5: h5py.File, n_points: int) -> dict[str, np.ndarray]:
+    if "vectors" not in h5 or "vector_names" not in h5:
+        return {}
+
+    names = [_decode_name(v) for v in np.asarray(h5["vector_names"][...]).ravel()]
+    if not names:
+        return {}
+
+    vectors = np.asarray(h5["vectors"][...])
+    if vectors.ndim != 2:
+        raise QueryError(f"Expected 2D dataset 'vectors' but found shape={vectors.shape}")
+
+    if vectors.shape[0] == len(names) and vectors.shape[1] == n_points:
+        matrix = vectors
+    elif vectors.shape[1] == len(names) and vectors.shape[0] == n_points:
+        matrix = vectors.T
+    else:
+        raise QueryError(
+            "Could not align 'vectors' with 'vector_names' and 'indep_var'. "
+            f"vectors={vectors.shape}, names={len(names)}, indep_len={n_points}"
+        )
+
+    # Remove indep vector if present in names.
+    indep_name = _decode_name(h5["indep_var"].attrs.get("name", ""))
+    out: dict[str, np.ndarray] = {}
+    for idx, name in enumerate(names):
+        if name == indep_name:
+            continue
+        out[name] = np.asarray(matrix[idx])
+    return out
+
+
+def load_signal_table(path: str) -> SignalTable:
+    with h5py.File(path, "r") as h5:
+        indep = _load_indep(h5)
+        signals = _load_signals_from_group(h5, indep.shape[0])
+        if not signals:
+            signals = _load_signals_from_vectors(h5, indep.shape[0])
+
+    if not signals:
+        raise QueryError(
+            "No queryable signals found. Expected either a 'signals' group or {'vectors','vector_names'} datasets."
+        )
+
+    return SignalTable(indep=indep, signals=signals)
+
+
+def _json_default(obj: Any) -> Any:
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.floating, np.integer)):
+        return obj.item()
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    return str(obj)
+
+
+def _emit(payload: dict[str, Any], out_format: str) -> None:
+    if out_format == "json":
+        print(json.dumps(payload, default=_json_default, separators=(",", ":")))
+        return
+
+    # text
+    command = payload.get("command", "")
+    if command == "list-signals":
+        for name in payload.get("signals", []):
+            print(name)
+    elif command == "summary":
+        print(f"points: {payload.get('points')}")
+        print(f"x_min: {payload.get('x_min')}")
+        print(f"x_max: {payload.get('x_max')}")
+        print(f"signal_count: {payload.get('signal_count')}")
+        preview = payload.get("signals_preview", [])
+        if preview:
+            print("signals_preview: " + ", ".join(preview))
+    elif command in {"head", "range"}:
+        print(f"signal: {payload.get('signal')}")
+        print(f"count: {payload.get('count')}")
+        for x, y in payload.get("points", []):
+            print(f"{x}\t{y}")
+    else:
+        print(payload)
+
+
+def cmd_list_signals(path: str) -> dict[str, Any]:
+    table = load_signal_table(path)
+    return {
+        "command": "list-signals",
+        "file": path,
+        "count": len(table.signals),
+        "signals": sorted(table.signals.keys()),
+    }
+
+
+def cmd_summary(path: str) -> dict[str, Any]:
+    table = load_signal_table(path)
+    x = table.indep
+    names = sorted(table.signals.keys())
+    return {
+        "command": "summary",
+        "file": path,
+        "points": int(x.shape[0]),
+        "x_min": float(np.min(x)),
+        "x_max": float(np.max(x)),
+        "signal_count": len(names),
+        "signals_preview": names[:10],
+    }
+
+
+def _must_get_signal(table: SignalTable, signal: str) -> np.ndarray:
+    if signal not in table.signals:
+        available = sorted(table.signals.keys())
+        preview = ", ".join(available[:20])
+        suffix = " ..." if len(available) > 20 else ""
+        raise QueryError(f"Signal '{signal}' not found. Available: {preview}{suffix}")
+    return table.signals[signal]
+
+
+def cmd_head(path: str, signal: str, n: int) -> dict[str, Any]:
+    if n <= 0:
+        raise QueryError("--n must be a positive integer")
+
+    table = load_signal_table(path)
+    y = _must_get_signal(table, signal)
+    x = table.indep
+    n_take = min(n, x.shape[0])
+
+    points = [[x[i], y[i]] for i in range(n_take)]
+    return {
+        "command": "head",
+        "file": path,
+        "signal": signal,
+        "count": len(points),
+        "points": points,
+    }
+
+
+def cmd_range(path: str, signal: str, x0: float, x1: float) -> dict[str, Any]:
+    if x1 < x0:
+        raise QueryError("Invalid range: require x1 >= x0")
+
+    table = load_signal_table(path)
+    y = _must_get_signal(table, signal)
+    x = table.indep
+
+    mask = (x >= x0) & (x <= x1)
+    idx = np.nonzero(mask)[0]
+    if idx.size == 0:
+        raise QueryError(
+            f"No points in requested range [{x0}, {x1}]. Data domain is [{float(np.min(x))}, {float(np.max(x))}]"
+        )
+
+    points = [[x[i], y[i]] for i in idx]
+    return {
+        "command": "range",
+        "file": path,
+        "signal": signal,
+        "x0": x0,
+        "x1": x1,
+        "count": len(points),
+        "points": points,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Query normalized HDF5 waveform artifacts")
+    parser.add_argument("file", help="Path to normalized HDF5 file")
+    parser.add_argument("--format", choices=["json", "text"], default="json", help="Output format")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list-signals", help="List available signal names")
+    subparsers.add_parser("summary", help="Show compact file summary")
+
+    p_head = subparsers.add_parser("head", help="Show first N points for a signal")
+    p_head.add_argument("--signal", required=True, help="Signal name")
+    p_head.add_argument("--n", type=int, default=10, help="Number of rows to return")
+
+    p_range = subparsers.add_parser("range", help="Show points in x-range for a signal")
+    p_range.add_argument("--signal", required=True, help="Signal name")
+    p_range.add_argument("--x0", required=True, type=float, help="Range start (inclusive)")
+    p_range.add_argument("--x1", required=True, type=float, help="Range end (inclusive)")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "list-signals":
+            payload = cmd_list_signals(args.file)
+        elif args.command == "summary":
+            payload = cmd_summary(args.file)
+        elif args.command == "head":
+            payload = cmd_head(args.file, args.signal, args.n)
+        elif args.command == "range":
+            payload = cmd_range(args.file, args.signal, args.x0, args.x1)
+        else:  # pragma: no cover
+            raise QueryError(f"Unsupported command: {args.command}")
+
+        _emit(payload, args.format)
+        return 0
+    except (OSError, QueryError, KeyError, ValueError) as exc:
+        _emit({"error": str(exc), "file": args.file, "command": args.command}, args.format)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analysis/tools/ngspice/normalize_raw.py
+++ b/analysis/tools/ngspice/normalize_raw.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Normalize ngspice ASCII RAW files into a stable HDF5 schema.
+
+Schema (root):
+- vectors:      (n_points, n_vars) float64/complex128
+- vector_names: (n_vars,) utf-8 strings
+- vector_kinds: (n_vars,) utf-8 strings
+- indep_var:    (n_points,) same dtype as vectors column
+- signals/:     one dataset per dependent vector (flat v1)
+
+CLI example:
+    python tools/normalize_raw.py --input outputs/raw/tran_square/tran_square.raw \
+        --output outputs/hdf5/tran_square.h5 --case-id tran_square
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+
+@dataclass
+class RawData:
+    header: dict[str, str]
+    names: list[str]
+    kinds: list[str]
+    values: np.ndarray  # shape=(n_points, n_vars)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _parse_scalar(token: str) -> complex | float:
+    tok = token.strip()
+    if "," in tok:
+        a, b = tok.split(",", 1)
+        return complex(float(a), float(b))
+    return float(tok)
+
+
+def _safe_dataset_name(name: str, idx: int) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9_.-]+", "_", name).strip("_")
+    if not safe:
+        safe = f"sig_{idx}"
+    return f"{idx:03d}_{safe}"
+
+
+def parse_ngspice_ascii_raw(raw_path: str | Path) -> RawData:
+    path = Path(raw_path)
+    raw_bytes = path.read_bytes()
+    text = raw_bytes.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+
+    header: dict[str, str] = {}
+    n_vars = None
+    n_points = None
+    i = 0
+
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith("Variables:"):
+            i += 1
+            break
+        if ":" in line:
+            k, v = line.split(":", 1)
+            header[k.strip()] = v.strip()
+            if k.strip().lower() == "no. variables":
+                n_vars = int(v.strip())
+            elif k.strip().lower() == "no. points":
+                n_points = int(v.strip())
+        i += 1
+
+    if n_vars is None or n_points is None:
+        raise ValueError("RAW header missing No. Variables / No. Points")
+
+    names: list[str] = []
+    kinds: list[str] = []
+    for _ in range(n_vars):
+        if i >= len(lines):
+            raise ValueError("Unexpected EOF while reading Variables section")
+        row = lines[i].strip()
+        i += 1
+        if not row:
+            continue
+        parts = row.split()
+        if len(parts) < 3:
+            raise ValueError(f"Bad variable row: {row!r}")
+        names.append(parts[1])
+        kinds.append(parts[2])
+
+    has_complex_flag = "complex" in header.get("Flags", "").lower()
+
+    # ASCII RAW path
+    j = i
+    while j < len(lines) and not lines[j].strip().startswith("Values:"):
+        j += 1
+    if j < len(lines):
+        j += 1
+        flat_vals: list[complex | float] = []
+        for line in lines[j:]:
+            s = line.strip()
+            if not s:
+                continue
+            parts = s.split()
+            if len(parts) >= 2 and re.fullmatch(r"[+-]?\d+", parts[0]):
+                token = parts[1]
+            else:
+                token = parts[-1]
+            flat_vals.append(_parse_scalar(token))
+
+        expected = n_points * n_vars
+        if len(flat_vals) != expected:
+            raise ValueError(
+                f"Parsed {len(flat_vals)} values, expected {expected} (= {n_points}x{n_vars}); RAW format mismatch"
+            )
+
+        has_complex = any(isinstance(v, complex) and v.imag != 0 for v in flat_vals)
+        dtype = np.complex128 if has_complex else np.float64
+        arr = np.asarray(flat_vals, dtype=dtype).reshape(n_points, n_vars)
+        return RawData(header=header, names=names, kinds=kinds, values=arr)
+
+    # Binary RAW path
+    marker = b"Binary:\n"
+    idx = raw_bytes.find(marker)
+    if idx < 0:
+        marker = b"Binary:\r\n"
+        idx = raw_bytes.find(marker)
+    if idx < 0:
+        raise ValueError("RAW file missing both Values and Binary sections")
+
+    blob = raw_bytes[idx + len(marker) :]
+    if len(blob) % 8 != 0:
+        # tolerate a trailing newline/padding byte if present
+        blob = blob[: len(blob) - (len(blob) % 8)]
+    vals = np.frombuffer(blob, dtype="<f8")
+
+    expected_real = n_points * n_vars
+    expected_complex = expected_real * 2
+
+    if has_complex_flag:
+        if vals.size != expected_complex:
+            raise ValueError(f"Binary complex RAW size mismatch: got {vals.size}, expected {expected_complex}")
+        arr = vals.reshape(n_points, n_vars, 2)
+        out = arr[..., 0] + 1j * arr[..., 1]
+    else:
+        if vals.size != expected_real:
+            raise ValueError(f"Binary real RAW size mismatch: got {vals.size}, expected {expected_real}")
+        out = vals.reshape(n_points, n_vars)
+
+    return RawData(header=header, names=names, kinds=kinds, values=out)
+
+
+def normalize_raw_to_hdf5(
+    raw_path: str | Path,
+    hdf5_path: str | Path,
+    *,
+    case_id: str | None = None,
+    simulator: str = "ngspice",
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    raw_path = Path(raw_path)
+    hdf5_path = Path(hdf5_path)
+    hdf5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    parsed = parse_ngspice_ascii_raw(raw_path)
+
+    if parsed.values.ndim != 2 or parsed.values.shape[1] != len(parsed.names):
+        raise ValueError("Shape consistency check failed for vectors")
+
+    indep_idx = 0
+    for idx, (nm, kd) in enumerate(zip(parsed.names, parsed.kinds)):
+        if nm.lower() in {"time", "frequency"} or kd.lower() in {"time", "frequency"}:
+            indep_idx = idx
+            break
+
+    indep_var = parsed.values[:, indep_idx]
+    if indep_var.size == 0:
+        raise ValueError("Independent variable is empty")
+
+    with h5py.File(hdf5_path, "w") as h5:
+        str_dt = h5py.string_dtype("utf-8")
+
+        h5.create_dataset("vectors", data=parsed.values)
+        h5.create_dataset("vector_names", data=np.asarray(parsed.names, dtype=object), dtype=str_dt)
+        h5.create_dataset("vector_kinds", data=np.asarray(parsed.kinds, dtype=object), dtype=str_dt)
+        h5.create_dataset("indep_var", data=indep_var)
+
+        sig_grp = h5.create_group("signals")
+        for idx, (name, kind) in enumerate(zip(parsed.names, parsed.kinds)):
+            if idx == indep_idx:
+                continue
+            ds = sig_grp.create_dataset(_safe_dataset_name(name, idx), data=parsed.values[:, idx])
+            ds.attrs["name"] = name
+            ds.attrs["kind"] = kind
+            ds.attrs["source_index"] = idx
+
+        h5.attrs["schema_version"] = "S-102.v1"
+        h5.attrs["created_utc"] = datetime.now(timezone.utc).isoformat()
+        h5.attrs["source_file"] = str(raw_path)
+        h5.attrs["source_sha256"] = _sha256_file(raw_path)
+        h5.attrs["simulator"] = simulator
+        if case_id:
+            h5.attrs["case_id"] = case_id
+        h5.attrs["n_points"] = int(parsed.values.shape[0])
+        h5.attrs["n_vars"] = int(parsed.values.shape[1])
+        h5.attrs["indep_var_index"] = indep_idx
+        h5.attrs["indep_var_name"] = parsed.names[indep_idx]
+        h5.attrs["quality_status"] = "ok"
+        h5.attrs["integrity_checks"] = json.dumps(
+            {
+                "shape_consistent": True,
+                "indep_var_present": True,
+            }
+        )
+
+        for k, v in (metadata or {}).items():
+            try:
+                h5.attrs[f"meta_{k}"] = v
+            except TypeError:
+                h5.attrs[f"meta_{k}"] = json.dumps(v)
+
+    return {
+        "raw_path": str(raw_path),
+        "hdf5_path": str(hdf5_path),
+        "n_points": int(parsed.values.shape[0]),
+        "n_vars": int(parsed.values.shape[1]),
+        "indep_var": parsed.names[indep_idx],
+    }
+
+
+def _parse_meta_items(items: list[str]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"Bad --meta item {item!r}; expected key=value")
+        k, v = item.split("=", 1)
+        out[k] = v
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Normalize ngspice ASCII RAW to HDF5")
+    ap.add_argument("--input", "-i", required=True, help="Input ngspice RAW file")
+    ap.add_argument("--output", "-o", required=True, help="Output HDF5 path")
+    ap.add_argument("--case-id", default=None, help="Optional case identifier")
+    ap.add_argument("--simulator", default="ngspice", help="Simulator label metadata")
+    ap.add_argument("--meta", action="append", default=[], help="Additional metadata key=value (repeatable)")
+
+    args = ap.parse_args(argv)
+    meta = _parse_meta_items(args.meta)
+    info = normalize_raw_to_hdf5(
+        args.input,
+        args.output,
+        case_id=args.case_id,
+        simulator=args.simulator,
+        metadata=meta,
+    )
+    print(json.dumps(info, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analysis/tools/ngspice/plot_waveforms.py
+++ b/analysis/tools/ngspice/plot_waveforms.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Plot normalized HDF5 waveforms and save PNG figures.
+
+Examples
+--------
+python tools/plot_waveforms.py \
+  --input outputs/hdf5/tran_square.h5 \
+  --signals 001_v_in 002_v_out \
+  --mode transient \
+  --output outputs/plots/tran_square_overlay.png
+
+python tools/plot_waveforms.py \
+  --input outputs/hdf5/ac_onepole.h5 \
+  --signals 002_v_out \
+  --mode ac \
+  --output outputs/plots/ac_onepole_bode.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import h5py
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("h5py is required. Install with: pip install h5py") from exc
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("matplotlib is required. Install with: pip install matplotlib") from exc
+
+
+class PlotError(RuntimeError):
+    """Raised for actionable plotting failures."""
+
+
+@dataclass
+class SignalTable:
+    indep: np.ndarray
+    indep_name: str
+    signals: dict[str, np.ndarray]
+    aliases: dict[str, str]
+
+
+def _decode_name(value: object) -> str:
+    if isinstance(value, (bytes, np.bytes_)):
+        return bytes(value).decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _as_1d(arr: np.ndarray) -> np.ndarray:
+    out = np.asarray(arr)
+    if out.ndim == 0:
+        out = out.reshape(1)
+    if out.ndim != 1:
+        raise PlotError(f"Expected 1D dataset, got shape={out.shape}")
+    return out
+
+
+def load_signal_table(path: str | Path) -> SignalTable:
+    with h5py.File(path, "r") as h5:
+        if "indep_var" not in h5:
+            raise PlotError("Missing required dataset: indep_var")
+        indep = _as_1d(h5["indep_var"][...])
+        indep_name = _decode_name(h5.attrs.get("indep_var_name", "indep_var"))
+
+        if "signals" not in h5 or not isinstance(h5["signals"], h5py.Group):
+            raise PlotError("Missing required group: signals")
+
+        signals: dict[str, np.ndarray] = {}
+        aliases: dict[str, str] = {}
+        for key in h5["signals"].keys():
+            ds = h5["signals"][key]
+            values = _as_1d(ds[...])
+            if values.shape[0] != indep.shape[0]:
+                raise PlotError(
+                    f"Signal '{key}' length={values.shape[0]} does not match indep_var length={indep.shape[0]}"
+                )
+            signals[key] = values
+            aliases[key] = key
+
+            raw_name = _decode_name(ds.attrs.get("name", "")).strip()
+            if raw_name and raw_name not in aliases:
+                aliases[raw_name] = key
+
+    return SignalTable(indep=indep, indep_name=indep_name, signals=signals, aliases=aliases)
+
+
+def _resolve_signals(table: SignalTable, requested: list[str]) -> list[tuple[str, np.ndarray]]:
+    resolved: list[tuple[str, np.ndarray]] = []
+    for name in requested:
+        key = table.aliases.get(name)
+        if key is None:
+            available = sorted(table.signals.keys())
+            raise PlotError(
+                f"Signal '{name}' not found. Available dataset keys: {', '.join(available[:20])}"
+            )
+        resolved.append((name, table.signals[key]))
+    return resolved
+
+
+def _prepare_x(indep: np.ndarray, indep_name: str, mode: str) -> tuple[np.ndarray, str, bool]:
+    x = indep
+    semilog = mode == "ac"
+    label = indep_name
+
+    if np.iscomplexobj(x):
+        x = np.abs(x)
+        label = f"|{indep_name}|"
+
+    x = np.asarray(x, dtype=float)
+    if mode == "ac":
+        semilog = np.all(x > 0)
+        if indep_name.lower() in {"frequency", "freq"}:
+            label = "Frequency (Hz)"
+    elif indep_name.lower() == "time":
+        label = "Time (s)"
+
+    return x, label, semilog
+
+
+def plot_transient(ax: plt.Axes, x: np.ndarray, series: list[tuple[str, np.ndarray]]) -> None:
+    for name, y in series:
+        if np.iscomplexobj(y):
+            y = np.real(y)
+        ax.plot(x, np.asarray(y, dtype=float), label=name, linewidth=1.4)
+    ax.set_ylabel("Amplitude")
+
+
+def plot_ac(
+    fig: plt.Figure,
+    x: np.ndarray,
+    series: list[tuple[str, np.ndarray]],
+    semilog: bool,
+) -> tuple[plt.Axes, plt.Axes]:
+    ax_mag = fig.add_subplot(2, 1, 1)
+    ax_phase = fig.add_subplot(2, 1, 2, sharex=ax_mag)
+
+    for name, y in series:
+        yc = np.asarray(y, dtype=np.complex128)
+        mag_db = 20.0 * np.log10(np.maximum(np.abs(yc), 1e-30))
+        phase_deg = np.unwrap(np.angle(yc)) * 180.0 / np.pi
+        if semilog:
+            ax_mag.semilogx(x, mag_db, label=name, linewidth=1.4)
+            ax_phase.semilogx(x, phase_deg, label=name, linewidth=1.4)
+        else:
+            ax_mag.plot(x, mag_db, label=name, linewidth=1.4)
+            ax_phase.plot(x, phase_deg, label=name, linewidth=1.4)
+
+    ax_mag.set_ylabel("Magnitude (dB)")
+    ax_phase.set_ylabel("Phase (deg)")
+    return ax_mag, ax_phase
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Plot normalized HDF5 waveforms to PNG")
+    parser.add_argument("--input", "-i", required=True, help="Input normalized HDF5 file")
+    parser.add_argument("--signals", "-s", nargs="+", required=True, help="Signal names to plot")
+    parser.add_argument("--output", "-o", required=True, help="Output PNG path")
+    parser.add_argument("--mode", choices=["transient", "ac", "auto"], default="auto")
+    parser.add_argument("--title", default=None, help="Optional figure title")
+    parser.add_argument("--style", default="seaborn-v0_8-whitegrid", help="Matplotlib style name")
+    parser.add_argument("--dpi", type=int, default=140, help="Output image DPI")
+    parser.add_argument("--figsize", nargs=2, type=float, default=[10.0, 4.0], metavar=("W", "H"))
+    return parser
+
+
+def _infer_mode(indep_name: str, indep: np.ndarray) -> str:
+    if indep_name.lower() in {"frequency", "freq"}:
+        return "ac"
+    if np.iscomplexobj(indep):
+        return "ac"
+    return "transient"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        table = load_signal_table(args.input)
+        selected = _resolve_signals(table, args.signals)
+        mode = args.mode if args.mode != "auto" else _infer_mode(table.indep_name, table.indep)
+
+        plt.style.use(args.style)
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if mode == "ac":
+            fig = plt.figure(figsize=(args.figsize[0], max(args.figsize[1], 5.0)))
+        else:
+            fig, ax = plt.subplots(figsize=(args.figsize[0], args.figsize[1]))
+
+        x, x_label, semilog = _prepare_x(table.indep, table.indep_name, mode)
+
+        if mode == "ac":
+            ax_mag, ax_phase = plot_ac(fig, x, selected, semilog=semilog)
+            ax_phase.set_xlabel(x_label)
+            ax_mag.grid(True, which="both", alpha=0.25)
+            ax_phase.grid(True, which="both", alpha=0.25)
+            ax_mag.legend(loc="best")
+        else:
+            plot_transient(ax, x, selected)
+            ax.set_xlabel(x_label)
+            ax.grid(True, alpha=0.25)
+            ax.legend(loc="best")
+
+        if args.title:
+            fig.suptitle(args.title)
+
+        fig.tight_layout()
+        fig.savefig(output_path, dpi=args.dpi)
+        plt.close(fig)
+        print(output_path)
+        return 0
+    except (OSError, ValueError, PlotError) as exc:
+        print(f"error: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analysis/tools/ngspice/run_analyzers.py
+++ b/analysis/tools/ngspice/run_analyzers.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.analyzers.ac_metrics import extract_ac_metrics
+from src.analyzers.cycle_extract import extract_cycles
+from src.analyzers.edge_events import extract_edge_events
+from src.analyzers.fft_topk import fft_topk
+
+CASE_ANALYZERS = {
+    "square": ("edge_events", "cycle_extract"),
+    "multitone": ("fft_topk",),
+    "ac_onepole": ("ac_metrics",),
+}
+
+
+class CaseLoadError(RuntimeError):
+    pass
+
+
+def _decode_name(x: Any) -> str:
+    if isinstance(x, bytes):
+        return x.decode("utf-8", errors="ignore")
+    return str(x)
+
+
+def _normalize_name(name: str) -> str:
+    return name.strip().lower().replace(" ", "")
+
+
+def _read_h5(path: Path) -> dict[str, Any]:
+    try:
+        import h5py  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError("h5py is required for tools/run_analyzers.py") from exc
+
+    signals: dict[str, np.ndarray] = {}
+    attrs: dict[str, Any] = {}
+
+    with h5py.File(path, "r") as h5:
+        attrs = {k: _decode_name(v) for k, v in h5.attrs.items()}
+
+        if "signals" in h5:
+            obj = h5["signals"]
+            if hasattr(obj, "items"):
+                for k, v in obj.items():
+                    signals[_decode_name(k)] = np.asarray(v)
+            else:
+                mat = np.asarray(obj)
+                names = []
+                if "vector_names" in h5:
+                    names = [_decode_name(n) for n in np.asarray(h5["vector_names"]).tolist()]
+                if names:
+                    for i, name in enumerate(names):
+                        if mat.ndim == 2:
+                            axis = mat[i] if mat.shape[0] == len(names) else mat[:, i]
+                            signals[name] = np.asarray(axis)
+
+        if "vectors" in h5 and "vector_names" in h5:
+            vec = np.asarray(h5["vectors"])
+            names = [_decode_name(n) for n in np.asarray(h5["vector_names"]).tolist()]
+            if vec.ndim == 2 and names:
+                for i, name in enumerate(names):
+                    if name not in signals:
+                        axis = vec[i] if vec.shape[0] == len(names) else vec[:, i]
+                        signals[name] = np.asarray(axis)
+
+        indep_obj = h5.get("indep_var")
+        indep = None
+        if indep_obj is not None:
+            indep_arr = np.asarray(indep_obj)
+            if indep_arr.ndim == 0 and indep_arr.dtype.kind in {"S", "U", "O"}:
+                indep = _decode_name(indep_arr.item())
+            elif indep_arr.ndim == 1 and np.issubdtype(indep_arr.dtype, np.number):
+                indep = indep_arr
+            else:
+                try:
+                    indep = _decode_name(indep_arr.item())
+                except Exception:
+                    indep = None
+
+    return {"signals": signals, "attrs": attrs, "indep": indep}
+
+
+def _pick_signal(signals: dict[str, np.ndarray], candidates: list[str], *, exclude: set[str] | None = None) -> np.ndarray | None:
+    exclude = exclude or set()
+    canon = { _normalize_name(k): k for k in signals.keys() }
+
+    for cand in candidates:
+        key = canon.get(_normalize_name(cand))
+        if key and key not in exclude:
+            arr = np.asarray(signals[key]).squeeze()
+            if arr.ndim == 1:
+                return arr
+
+    for k, arr in signals.items():
+        if k in exclude:
+            continue
+        arr = np.asarray(arr).squeeze()
+        if arr.ndim == 1 and np.issubdtype(arr.dtype, np.number):
+            return arr
+    return None
+
+
+def _infer_case_type(path: Path, attrs: dict[str, Any]) -> str | None:
+    for k in ("case_type", "fixture", "case"):
+        if k in attrs:
+            val = str(attrs[k]).lower()
+            for ct in CASE_ANALYZERS:
+                if ct in val:
+                    return ct
+
+    stem = path.stem.lower()
+    for ct in CASE_ANALYZERS:
+        if ct in stem:
+            return ct
+    return None
+
+
+def _extract_transient_xy(data: dict[str, Any]) -> tuple[np.ndarray, np.ndarray]:
+    signals = data["signals"]
+    indep = data["indep"]
+
+    t = None
+    if isinstance(indep, np.ndarray):
+        t = indep
+    elif isinstance(indep, str) and indep in signals:
+        t = np.asarray(signals[indep]).squeeze()
+
+    if t is None:
+        t = _pick_signal(signals, ["t", "time", "tran_time", "seconds"])
+
+    if t is None:
+        raise CaseLoadError("Could not resolve transient independent variable (time)")
+
+    y = _pick_signal(
+        signals,
+        ["v(out)", "out", "vout", "y", "signal", "vin", "v(in)"],
+        exclude={k for k, v in signals.items() if np.array_equal(np.asarray(v).squeeze(), t)},
+    )
+    if y is None:
+        raise CaseLoadError("Could not resolve transient dependent waveform")
+
+    return np.asarray(t, dtype=float), np.asarray(y, dtype=float)
+
+
+def _extract_ac_arrays(data: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    signals = data["signals"]
+    indep = data["indep"]
+
+    f = None
+    if isinstance(indep, np.ndarray):
+        f = indep
+    elif isinstance(indep, str) and indep in signals:
+        f = np.asarray(signals[indep]).squeeze()
+
+    if f is None:
+        f = _pick_signal(signals, ["f_hz", "freq", "frequency", "f"])
+
+    if f is None:
+        raise CaseLoadError("Could not resolve AC independent variable (frequency)")
+
+    gain = _pick_signal(signals, ["gain_db", "mag_db", "db(v(out))", "vdb(out)", "gain"])
+    phase = _pick_signal(signals, ["phase_deg", "phase", "ph(out)", "vp(out)"])
+
+    if gain is None or phase is None:
+        resp = _pick_signal(signals, ["v(out)", "out", "response", "resp"])
+        if resp is not None and np.iscomplexobj(resp):
+            if gain is None:
+                gain = 20.0 * np.log10(np.maximum(np.abs(resp), 1e-15))
+            if phase is None:
+                phase = np.rad2deg(np.angle(resp))
+
+    if gain is None:
+        raise CaseLoadError("Could not resolve AC gain_db vector")
+    if phase is None:
+        raise CaseLoadError("Could not resolve AC phase_deg vector")
+
+    return np.asarray(f, dtype=float), np.asarray(gain, dtype=float), np.asarray(phase, dtype=float)
+
+
+def _run_case(path: Path, out_dir: Path, forced_case_type: str | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "case": path.stem,
+        "input_hdf5": str(path),
+        "status": "ok",
+        "analyzers": {},
+        "quality": {"status": "ok", "reasons": []},
+    }
+
+    try:
+        data = _read_h5(path)
+        case_type = forced_case_type or _infer_case_type(path, data["attrs"])
+        if case_type not in CASE_ANALYZERS:
+            raise CaseLoadError(
+                f"Could not determine case_type for '{path.name}'. "
+                f"Use --case-type one of {sorted(CASE_ANALYZERS)}"
+            )
+        payload["case_type"] = case_type
+
+        if case_type in {"square", "multitone"}:
+            t, y = _extract_transient_xy(data)
+            payload["inputs_summary"] = {
+                "n_samples": int(len(t)),
+                "x_span": [float(t[0]), float(t[-1])],
+            }
+
+            if case_type == "square":
+                for analyzer_name in CASE_ANALYZERS[case_type]:
+                    try:
+                        if analyzer_name == "edge_events":
+                            payload["analyzers"][analyzer_name] = extract_edge_events(t=t, y=y)
+                        elif analyzer_name == "cycle_extract":
+                            payload["analyzers"][analyzer_name] = extract_cycles(t=t, y=y)
+                    except Exception as exc:
+                        payload["analyzers"][analyzer_name] = {
+                            "quality": {"status": "bad", "reasons": [str(exc)]},
+                            "error": str(exc),
+                        }
+                        payload["quality"]["status"] = "warn"
+                        payload["quality"]["reasons"].append(f"{analyzer_name}_failed")
+
+            elif case_type == "multitone":
+                try:
+                    payload["analyzers"]["fft_topk"] = fft_topk(t=t, y=y)
+                except Exception as exc:
+                    payload["analyzers"]["fft_topk"] = {
+                        "quality": {"status": "bad", "reasons": [str(exc)]},
+                        "error": str(exc),
+                    }
+                    payload["quality"]["status"] = "warn"
+                    payload["quality"]["reasons"].append("fft_topk_failed")
+
+        elif case_type == "ac_onepole":
+            f_hz, gain_db, phase_deg = _extract_ac_arrays(data)
+            payload["inputs_summary"] = {
+                "n_points": int(len(f_hz)),
+                "f_span_hz": [float(f_hz[0]), float(f_hz[-1])],
+            }
+            try:
+                payload["analyzers"]["ac_metrics"] = extract_ac_metrics(
+                    f_hz=f_hz, gain_db=gain_db, phase_deg=phase_deg
+                )
+            except Exception as exc:
+                payload["analyzers"]["ac_metrics"] = {
+                    "quality": {"status": "bad", "reasons": [str(exc)]},
+                    "error": str(exc),
+                }
+                payload["quality"]["status"] = "warn"
+                payload["quality"]["reasons"].append("ac_metrics_failed")
+
+    except Exception as exc:
+        payload["status"] = "error"
+        payload["quality"] = {"status": "bad", "reasons": [str(exc)]}
+        payload["error"] = str(exc)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{path.stem}.json"
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return payload
+
+
+def _collect_inputs(input_path: Path, pattern: str) -> list[Path]:
+    if input_path.is_file():
+        return [input_path]
+    if not input_path.exists():
+        return []
+
+    files = sorted(input_path.glob(pattern))
+    return [p for p in files if p.is_file()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run prototype analyzers over normalized HDF5 cases and emit JSON outputs."
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("outputs/normalized"),
+        help="Input HDF5 file or directory (default: outputs/normalized)",
+    )
+    parser.add_argument(
+        "--pattern",
+        default="*.h5",
+        help="Glob pattern when --input is a directory (default: *.h5)",
+    )
+    parser.add_argument(
+        "--case-type",
+        choices=sorted(CASE_ANALYZERS),
+        default=None,
+        help="Optional override case type for all selected inputs",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/analysis"),
+        help="Output directory for per-case JSON (default: outputs/analysis)",
+    )
+    args = parser.parse_args()
+
+    paths = _collect_inputs(args.input, args.pattern)
+    if not paths:
+        print(f"No input files found at {args.input} (pattern={args.pattern})")
+        return 1
+
+    statuses = []
+    for path in paths:
+        payload = _run_case(path=path, out_dir=args.output_dir, forced_case_type=args.case_type)
+        statuses.append(payload.get("status", "error"))
+        print(f"[{payload.get('status', 'error')}] {path.name} -> {args.output_dir / (path.stem + '.json')}")
+
+    return 0 if any(s == "ok" for s in statuses) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analysis/tools/ngspice/tests/test_normalize_raw.py
+++ b/analysis/tools/ngspice/tests/test_normalize_raw.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from tools.normalize_raw import normalize_raw_to_hdf5
+
+
+SAMPLE_RAW = """Title: synthetic tran
+Date: Wed Mar 04 00:00:00 2026
+Plotname: Transient Analysis
+Flags: real
+No. Variables: 3
+No. Points: 4
+Variables:
+	0	time	time
+	1	v(in)	voltage
+	2	v(out)	voltage
+Values:
+	0	0.0
+	1	0.0
+	2	0.0
+	1	1e-9
+	1	1.0
+	2	0.5
+	2	2e-9
+	1	0.0
+	2	1.0
+	3	3e-9
+	1	1.0
+	2	1.5
+"""
+
+
+def _write_sample_raw(tmp_path: Path) -> Path:
+    raw = tmp_path / "sample.raw"
+    raw.write_text(SAMPLE_RAW, encoding="utf-8")
+    return raw
+
+
+def test_normalize_raw_library_smoke(tmp_path: Path):
+    raw = _write_sample_raw(tmp_path)
+    out = tmp_path / "sample.h5"
+
+    info = normalize_raw_to_hdf5(raw, out, case_id="sample_case")
+
+    assert out.exists()
+    assert info["n_points"] == 4
+    assert info["n_vars"] == 3
+    assert info["indep_var"] == "time"
+
+    with h5py.File(out, "r") as h5:
+        assert h5["vectors"].shape == (4, 3)
+        assert list(h5["vector_names"].asstr()[:]) == ["time", "v(in)", "v(out)"]
+        assert "vector_kinds" in h5
+        assert "indep_var" in h5
+        assert "signals" in h5
+        assert len(h5["signals"].keys()) == 2
+        np.testing.assert_allclose(h5["indep_var"][:], [0.0, 1e-9, 2e-9, 3e-9])
+        assert h5.attrs["quality_status"] == "ok"
+
+
+def test_normalize_raw_cli_smoke(tmp_path: Path):
+    raw = _write_sample_raw(tmp_path)
+    out = tmp_path / "cli.h5"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "tools/normalize_raw.py",
+            "--input",
+            str(raw),
+            "--output",
+            str(out),
+            "--case-id",
+            "cli_case",
+            "--meta",
+            "corner=tt",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert out.exists()
+    assert "cli.h5" in proc.stdout
+
+    with h5py.File(out, "r") as h5:
+        assert h5.attrs["case_id"] == "cli_case"
+        assert h5.attrs["meta_corner"] == "tt"
+
+
+def test_convert_all_existing_fixture_raw_files(tmp_path: Path):
+    repo = Path(__file__).resolve().parents[1]
+    raw_files = sorted(repo.glob("outputs/raw/**/*.raw"))
+
+    # If no fixtures exist yet, we still validate conversion path using synthetic RAW.
+    if not raw_files:
+        raw_files = [_write_sample_raw(tmp_path)]
+
+    for i, raw in enumerate(raw_files):
+        h5_out = tmp_path / f"fixture_{i}.h5"
+        normalize_raw_to_hdf5(raw, h5_out, case_id=raw.stem)
+        with h5py.File(h5_out, "r") as h5:
+            assert h5["vectors"].shape[0] > 0
+            assert h5["vectors"].shape[1] >= 2
+            assert h5["indep_var"].shape[0] == h5["vectors"].shape[0]

--- a/analysis/tools/ngspice/tests/test_plot_waveforms_smoke.py
+++ b/analysis/tools/ngspice/tests/test_plot_waveforms_smoke.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_plot_waveforms_smoke(tmp_path: Path) -> None:
+    out_png = tmp_path / "tran_square_smoke.png"
+
+    cmd = [
+        sys.executable,
+        "tools/plot_waveforms.py",
+        "--input",
+        "outputs/hdf5/tran_square.h5",
+        "--signals",
+        "001_v_in",
+        "002_v_out",
+        "--mode",
+        "transient",
+        "--output",
+        str(out_png),
+    ]
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert out_png.exists()
+    assert out_png.stat().st_size > 0

--- a/examples/ngspice_fixtures/netlists/ac_onepole.spice
+++ b/examples/ngspice_fixtures/netlists/ac_onepole.spice
@@ -1,0 +1,8 @@
+* ac_onepole.spice -- one-pole RC low-pass AC fixture
+Vin in 0 AC 1
+R1 in out 1k
+C1 out 0 1n
+
+.save v(in) v(out)
+.ac dec 200 10 1e6
+.end

--- a/examples/ngspice_fixtures/netlists/tran_multitone.spice
+++ b/examples/ngspice_fixtures/netlists/tran_multitone.spice
@@ -1,0 +1,8 @@
+* tran_multitone.spice -- deterministic multi-tone transient fixture
+* Sum of tones at 1 kHz, 3 kHz, and 7 kHz
+B1 out 0 V = 0.8*sin(2*pi*1k*time) + 0.4*sin(2*pi*3k*time) + 0.2*sin(2*pi*7k*time)
+Rload out 0 1k
+
+.save v(out)
+.tran 2u 20m
+.end

--- a/examples/ngspice_fixtures/netlists/tran_square.spice
+++ b/examples/ngspice_fixtures/netlists/tran_square.spice
@@ -1,0 +1,8 @@
+* tran_square.spice -- deterministic square-wave transient fixture
+V1 in 0 PULSE(0 1.2 0 1n 1n 5u 10u)
+R1 in out 1k
+C1 out 0 1n
+
+.save v(in) v(out)
+.tran 100n 100u
+.end

--- a/examples/ngspice_fixtures/scripts/e2e.py
+++ b/examples/ngspice_fixtures/scripts/e2e.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass
+class StageResult:
+    name: str
+    ok: bool
+    command: list[str] | None = None
+    details: str | None = None
+
+
+def _run_cmd(stage: str, cmd: list[str], cwd: Path) -> StageResult:
+    proc = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True)
+    if proc.returncode == 0:
+        return StageResult(name=stage, ok=True, command=cmd)
+
+    stderr = (proc.stderr or "").strip()
+    stdout = (proc.stdout or "").strip()
+    tail = stderr or stdout or "(no output)"
+    if len(tail) > 600:
+        tail = tail[-600:]
+    return StageResult(
+        name=stage,
+        ok=False,
+        command=cmd,
+        details=f"exit={proc.returncode}; tail={tail}",
+    )
+
+
+def _run_first_success(stage: str, commands: list[list[str]], cwd: Path) -> StageResult:
+    last_fail: StageResult | None = None
+    for cmd in commands:
+        rs = _run_cmd(stage, cmd, cwd)
+        if rs.ok:
+            return rs
+        last_fail = rs
+    assert last_fail is not None
+    return last_fail
+
+
+def _find_h5_files(hdf5_dir: Path) -> list[Path]:
+    if not hdf5_dir.exists():
+        return []
+    return sorted([*hdf5_dir.glob("*.h5"), *hdf5_dir.glob("*.hdf5")])
+
+
+def _query_smoke(cwd: Path, hdf5_dir: Path, query_script: Path) -> StageResult:
+    h5_files = _find_h5_files(hdf5_dir)
+    if not h5_files:
+        return StageResult(
+            name="query-smoke",
+            ok=False,
+            details=f"no HDF5 artifacts found in {hdf5_dir}",
+        )
+
+    for fp in h5_files:
+        rs = _run_first_success(
+            "query-smoke",
+            commands=[
+                [sys.executable, str(query_script), str(fp), "summary"],
+            ],
+            cwd=cwd,
+        )
+        if not rs.ok:
+            rs.details = f"file={fp}; {rs.details}"
+            return rs
+
+        rs = _run_first_success(
+            "query-smoke",
+            commands=[
+                [sys.executable, str(query_script), str(fp), "list-signals"],
+            ],
+            cwd=cwd,
+        )
+        if not rs.ok:
+            rs.details = f"file={fp}; {rs.details}"
+            return rs
+
+    return StageResult(name="query-smoke", ok=True, details=f"checked {len(h5_files)} file(s)")
+
+
+def _gather_artifacts(raw_dir: Path, hdf5_dir: Path, analysis_dir: Path) -> dict[str, list[str]]:
+    raw = sorted(str(p) for p in raw_dir.rglob("*.raw")) if raw_dir.exists() else []
+    h5 = sorted(str(p) for p in _find_h5_files(hdf5_dir))
+    analysis = sorted(str(p) for p in analysis_dir.rglob("*.json")) if analysis_dir.exists() else []
+    return {
+        "raw": raw,
+        "hdf5": h5,
+        "analysis": analysis,
+    }
+
+
+def _require_paths(paths: Iterable[Path]) -> list[str]:
+    missing: list[str] = []
+    for p in paths:
+        if not p.exists():
+            missing.append(str(p))
+    return missing
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Run end-to-end fixture->normalize->query->analyze regression.")
+    p.add_argument("--repo-root", default=".", help="Repository root containing scripts/ and tools/")
+    p.add_argument("--raw-dir", default="outputs/raw", help="RAW artifact directory")
+    p.add_argument("--hdf5-dir", default="outputs/hdf5", help="HDF5 artifact directory")
+    p.add_argument("--analysis-dir", default="outputs/analysis", help="Analysis artifact directory")
+    p.add_argument("--json", action="store_true", help="Emit machine-readable final summary JSON")
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    raw_dir = (repo_root / args.raw_dir).resolve()
+    hdf5_dir = (repo_root / args.hdf5_dir).resolve()
+    analysis_dir = (repo_root / args.analysis_dir).resolve()
+
+    fixture_runner = repo_root / "scripts" / "run_fixtures.py"
+    normalizer = repo_root / "tools" / "normalize_raw.py"
+    query_script = repo_root / "tools" / "h5_query.py"
+    analyzer_adapter = repo_root / "tools" / "run_analyzers.py"
+
+    missing = _require_paths([fixture_runner, normalizer, query_script, analyzer_adapter])
+    if missing:
+        msg = {
+            "status": "failed",
+            "failed_stage": "preflight",
+            "error": "missing required scripts",
+            "missing": missing,
+        }
+        if args.json:
+            print(json.dumps(msg, indent=2))
+        else:
+            print("❌ e2e failed at stage=preflight")
+            print("Missing required scripts:")
+            for m in missing:
+                print(f"- {m}")
+        return 2
+
+    # Ensure output directories exist (stages may rely on this).
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    hdf5_dir.mkdir(parents=True, exist_ok=True)
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    stages: list[StageResult] = []
+
+    stages.append(
+        _run_first_success(
+            "fixtures",
+            commands=[
+                [sys.executable, str(fixture_runner), "--out-dir", str(raw_dir)],
+                [sys.executable, str(fixture_runner)],
+            ],
+            cwd=repo_root,
+        )
+    )
+    if not stages[-1].ok:
+        return _finish(args.json, stages, raw_dir, hdf5_dir, analysis_dir)
+
+    raw_files = sorted(raw_dir.rglob("*.raw"))
+    if not raw_files:
+        stages.append(StageResult(name="normalize", ok=False, details=f"no RAW files found in {raw_dir}"))
+        return _finish(args.json, stages, raw_dir, hdf5_dir, analysis_dir)
+
+    for raw_fp in raw_files:
+        case_id = raw_fp.parent.name
+        out_fp = hdf5_dir / f"{case_id}.h5"
+        rs = _run_first_success(
+            "normalize",
+            commands=[
+                [
+                    sys.executable,
+                    str(normalizer),
+                    "--input",
+                    str(raw_fp),
+                    "--output",
+                    str(out_fp),
+                    "--case-id",
+                    case_id,
+                ],
+                [
+                    sys.executable,
+                    str(normalizer),
+                    "--raw",
+                    str(raw_fp),
+                    "--hdf5",
+                    str(out_fp),
+                    "--case-id",
+                    case_id,
+                ],
+            ],
+            cwd=repo_root,
+        )
+        if not rs.ok:
+            rs.details = f"raw={raw_fp}; {rs.details}"
+            stages.append(rs)
+            return _finish(args.json, stages, raw_dir, hdf5_dir, analysis_dir)
+    stages.append(StageResult(name="normalize", ok=True, details=f"converted {len(raw_files)} RAW file(s)"))
+
+    stages.append(_query_smoke(repo_root, hdf5_dir, query_script))
+    if not stages[-1].ok:
+        return _finish(args.json, stages, raw_dir, hdf5_dir, analysis_dir)
+
+    stages.append(
+        _run_first_success(
+            "analyzer-adapter",
+            commands=[
+                [sys.executable, str(analyzer_adapter), "--input", str(hdf5_dir), "--output-dir", str(analysis_dir)],
+            ],
+            cwd=repo_root,
+        )
+    )
+
+    return _finish(args.json, stages, raw_dir, hdf5_dir, analysis_dir)
+
+
+def _finish(json_mode: bool, stages: list[StageResult], raw_dir: Path, hdf5_dir: Path, analysis_dir: Path) -> int:
+    failed = next((s for s in stages if not s.ok), None)
+    artifacts = _gather_artifacts(raw_dir, hdf5_dir, analysis_dir)
+
+    payload = {
+        "status": "failed" if failed else "ok",
+        "failed_stage": failed.name if failed else None,
+        "stages": [
+            {
+                "name": s.name,
+                "ok": s.ok,
+                "command": s.command,
+                "details": s.details,
+            }
+            for s in stages
+        ],
+        "artifacts": artifacts,
+    }
+
+    if json_mode:
+        print(json.dumps(payload, indent=2))
+    else:
+        if failed:
+            print(f"❌ e2e failed at stage={failed.name}")
+            if failed.details:
+                print(f"   {failed.details}")
+        else:
+            print("✅ e2e succeeded")
+
+        print("Artifacts:")
+        print(f"- RAW:      {raw_dir}")
+        print(f"- HDF5:     {hdf5_dir}")
+        print(f"- Analysis: {analysis_dir}")
+
+        if failed:
+            print("Stage summary:")
+            for s in stages:
+                flag = "ok" if s.ok else "fail"
+                print(f"- {s.name}: {flag}")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ngspice_fixtures/scripts/run_fixtures.py
+++ b/examples/ngspice_fixtures/scripts/run_fixtures.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Run deterministic ngspice fixtures and collect RAW/log artifacts.
+
+Output layout:
+  outputs/raw/<case>/netlist.spice
+  outputs/raw/<case>/sim.raw
+  outputs/raw/<case>/sim.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+CASES = {
+    "tran_square": "tran_square.spice",
+    "tran_multitone": "tran_multitone.spice",
+    "ac_onepole": "ac_onepole.spice",
+}
+
+
+def run_case(case: str, src_netlist: Path, out_root: Path) -> None:
+    case_dir = out_root / case
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    netlist_out = case_dir / "netlist.spice"
+    raw_out = case_dir / "sim.raw"
+    log_out = case_dir / "sim.log"
+
+    shutil.copyfile(src_netlist, netlist_out)
+
+    cmd = [
+        "ngspice",
+        "-b",
+        "-a",  # force ASCII RAW so normalize_raw.py can parse fixture outputs
+        "-o",
+        str(log_out),
+        "-r",
+        str(raw_out),
+        str(netlist_out),
+    ]
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        err = proc.stderr.strip() or proc.stdout.strip() or f"ngspice failed for {case}"
+        raise RuntimeError(err)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run ngspice fixture netlists")
+    parser.add_argument(
+        "--cases",
+        nargs="+",
+        choices=sorted(CASES.keys()),
+        default=list(CASES.keys()),
+        help="Subset of fixture cases to run",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    netlists_dir = repo_root / "netlists"
+    out_root = repo_root / "outputs" / "raw"
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    for case in args.cases:
+        netlist_name = CASES[case]
+        src_netlist = netlists_dir / netlist_name
+        if not src_netlist.exists():
+            raise FileNotFoundError(f"Missing netlist for {case}: {src_netlist}")
+
+        print(f"[run_fixtures] running {case}")
+        run_case(case, src_netlist, out_root)
+
+    print("[run_fixtures] done")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ngspice_fixtures/specs/S-101_sim_fixtures_ngspice.md
+++ b/examples/ngspice_fixtures/specs/S-101_sim_fixtures_ngspice.md
@@ -1,0 +1,21 @@
+# S-101 — Minimal Simulation Fixtures (ngspice RAW producers)
+
+## Objective
+Create deterministic SPICE fixtures that generate RAW files for normalization and analyzer validation.
+
+## Scope
+- Add fixture netlists:
+  - `netlists/tran_square.spice`
+  - `netlists/tran_multitone.spice`
+  - `netlists/ac_onepole.spice`
+- Add runner script to execute all fixtures with ngspice and emit outputs into `outputs/raw/<case>/`.
+- Store simulator logs per case.
+
+## Out of Scope
+- Xyce execution in this phase.
+- Process-corner model libraries.
+
+## Definition of Done (DoD)
+- One command creates 3 RAW files and logs.
+- Output paths are deterministic and documented.
+- Fixtures are simple, readable, and reproducible.

--- a/examples/ngspice_fixtures/specs/S-102_ngspice_raw_to_hdf5.md
+++ b/examples/ngspice_fixtures/specs/S-102_ngspice_raw_to_hdf5.md
@@ -1,0 +1,24 @@
+# S-102 — RAW→HDF5 Normalizer (ngspice-focused)
+
+## Objective
+Normalize ngspice RAW outputs into a stable HDF5 structure for downstream querying and analysis.
+
+## Scope
+- Implement `tools/normalize_raw.py` (CLI + importable function).
+- Inputs: RAW file path, output HDF5 path, optional metadata (case_id, simulator).
+- Output HDF5 groups/datasets:
+  - `vectors`
+  - `vector_names`
+  - `vector_kinds` (if available)
+  - `indep_var`
+  - `signals` (flat v1 acceptable)
+- Include quality metadata attrs and source provenance.
+
+## Out of Scope
+- Universal RAW dialect support.
+- Multi-step sweep-in-one-file handling.
+
+## Definition of Done (DoD)
+- All S-101 fixture RAW files normalize without errors.
+- Integrity checks pass (shape consistency, independent variable present).
+- CLI usage documented in README or docs snippet.

--- a/examples/ngspice_fixtures/specs/S-103_hdf5_query_tool.md
+++ b/examples/ngspice_fixtures/specs/S-103_hdf5_query_tool.md
@@ -1,0 +1,21 @@
+# S-103 — HDF5 Query Tool (agent-facing)
+
+## Objective
+Provide compact, scriptable HDF5 queries so agents can inspect data without loading full traces.
+
+## Scope
+- Implement `tools/h5_query.py` with subcommands:
+  - `list-signals`
+  - `summary`
+  - `head --signal <name> --n <k>`
+  - `range --signal <name> --x0 --x1`
+- Default output JSON; optional plain text.
+
+## Out of Scope
+- Plot rendering.
+- SQL engine embedding.
+
+## Definition of Done (DoD)
+- Commands work on all normalized fixture HDF5 files.
+- Outputs are compact and machine-readable.
+- Error messages are actionable for missing signals/ranges.

--- a/examples/ngspice_fixtures/specs/S-104_analyzer_adapter.md
+++ b/examples/ngspice_fixtures/specs/S-104_analyzer_adapter.md
@@ -1,0 +1,22 @@
+# S-104 — Analyzer Adapter: HDF5 to prototype modules
+
+## Objective
+Run prototype analyzer modules directly from normalized HDF5 artifacts.
+
+## Scope
+- Implement `tools/run_analyzers.py`:
+  - load HDF5 signal vectors
+  - map case types to analyzer modules:
+    - square -> edge_events + cycle_extract
+    - multitone -> fft_topk
+    - ac_onepole -> ac_metrics
+- Emit per-case JSON results into `outputs/analysis/<case>.json`.
+
+## Out of Scope
+- Auto-discovery for arbitrary circuits.
+- Pole-zero model fitting.
+
+## Definition of Done (DoD)
+- Analyzer outputs created for all fixture cases.
+- Output JSON includes metrics and quality flags.
+- Failures are isolated per-case with clear status.

--- a/examples/ngspice_fixtures/specs/S-105_e2e_regression.md
+++ b/examples/ngspice_fixtures/specs/S-105_e2e_regression.md
@@ -1,0 +1,20 @@
+# S-105 — End-to-End Regression Orchestrator
+
+## Objective
+Provide a single command to run simulate -> normalize -> query-smoke -> analyze.
+
+## Scope
+- Implement `scripts/e2e.py` (or equivalent) to orchestrate:
+  1) ngspice fixture runs
+  2) RAW->HDF5 normalization
+  3) HDF5 query smoke checks
+  4) analyzer adapter execution
+- Fail-fast behavior with concise error summary.
+
+## Out of Scope
+- CI integration with remote services.
+
+## Definition of Done (DoD)
+- One command generates all expected artifacts under `outputs/`.
+- Non-zero exit on failures; clear stage attribution.
+- Success summary prints artifact locations.

--- a/examples/ngspice_fixtures/specs/S-106_fix_raw_normalization_path.md
+++ b/examples/ngspice_fixtures/specs/S-106_fix_raw_normalization_path.md
@@ -1,0 +1,21 @@
+# S-106 — Fix ngspice RAW normalization path to green E2E
+
+## Objective
+Resolve current E2E failure where ngspice fixture RAW format mismatches normalizer expectations.
+
+## Scope
+- Choose one robust path and implement end-to-end:
+  1) emit ASCII RAW from fixtures, or
+  2) add binary RAW support to normalizer.
+- Ensure `scripts/e2e.py` succeeds through normalize/query/analyze stages.
+- Keep tooling workflow-bound (no universal RAW parser ambition).
+- Use repo-local venv only (`.venv/` under repo root).
+
+## Out of Scope
+- Xyce runtime support in this fix.
+- Pole-zero fitting or new analyzer modules.
+
+## Definition of Done (DoD)
+- `python scripts/e2e.py --json` exits 0 in repo-local venv.
+- Artifacts exist in `outputs/raw`, `outputs/hdf5`, and `outputs/analysis`.
+- Brief fix note added to README with run command and venv usage.

--- a/examples/ngspice_fixtures/specs/S-107_waveform_plotter_png.md
+++ b/examples/ngspice_fixtures/specs/S-107_waveform_plotter_png.md
@@ -1,0 +1,23 @@
+# S-107 — Waveform Plotter (HDF5 -> PNG)
+
+## Objective
+Create a plotting tool that reads normalized HDF5 waveforms and writes PNG figures suitable for sharing.
+
+## Scope
+- Implement `tools/plot_waveforms.py` CLI.
+- Input: HDF5 file from normalizer.
+- Signal selection: one or multiple signal names.
+- Modes:
+  - transient: y vs independent variable (time)
+  - AC: gain/phase style optional, or generic y vs x fallback
+- Output: PNG in `outputs/plots/` (configurable path).
+- Optional style presets for readability.
+
+## Out of Scope
+- Interactive GUI.
+- Advanced publication layouts.
+
+## Definition of Done (DoD)
+- Can generate PNG from fixture HDF5 artifacts.
+- Works for at least transient and AC fixture cases.
+- CLI usage documented in README.

--- a/examples/ngspice_fixtures/tasks/T-101_sim_fixtures_ngspice.md
+++ b/examples/ngspice_fixtures/tasks/T-101_sim_fixtures_ngspice.md
@@ -1,0 +1,14 @@
+# T-101 — Build ngspice fixture netlists and runner
+
+## Objective
+Create 3 deterministic fixture netlists and a runner to produce RAW outputs.
+
+## Scope
+- Netlists: `tran_square`, `tran_multitone`, `ac_onepole`.
+- Runner: `scripts/run_fixtures.py`.
+- Output layout: `outputs/raw/<case>/{netlist.spice,*.raw,sim.log}`.
+
+## DoD
+- One command runs all fixtures.
+- 3 RAW files generated.
+- Logs captured per case.

--- a/examples/ngspice_fixtures/tasks/T-102_raw_to_hdf5_ngspice.md
+++ b/examples/ngspice_fixtures/tasks/T-102_raw_to_hdf5_ngspice.md
@@ -1,0 +1,14 @@
+# T-102 — Implement ngspice RAW->HDF5 normalizer
+
+## Objective
+Implement CLI tool to normalize fixture RAW files into HDF5.
+
+## Scope
+- `tools/normalize_raw.py` with function + CLI.
+- Preserve vectors and independent variable.
+- Emit provenance attrs and basic metadata.
+
+## DoD
+- All fixture RAW files convert successfully.
+- Output schema follows S-102.
+- Add/adjust tests for conversion smoke.

--- a/examples/ngspice_fixtures/tasks/T-103_hdf5_query_tool.md
+++ b/examples/ngspice_fixtures/tasks/T-103_hdf5_query_tool.md
@@ -1,0 +1,12 @@
+# T-103 — Implement HDF5 query tool
+
+## Objective
+Provide compact query operations for normalized HDF5 artifacts.
+
+## Scope
+- `tools/h5_query.py` with subcommands: list-signals, summary, head, range.
+- JSON output by default.
+
+## DoD
+- Query commands work on normalized fixture files.
+- Missing signal/range errors are clear.

--- a/examples/ngspice_fixtures/tasks/T-104_analyzer_adapter.md
+++ b/examples/ngspice_fixtures/tasks/T-104_analyzer_adapter.md
@@ -1,0 +1,12 @@
+# T-104 — Implement analyzer adapter over HDF5
+
+## Objective
+Wire normalized HDF5 signals into prototype analyzers and emit per-case results.
+
+## Scope
+- `tools/run_analyzers.py` with case presets for square/multitone/ac_onepole.
+- Save results to `outputs/analysis/*.json`.
+
+## DoD
+- All target analyzers run on relevant fixture cases.
+- Result JSON includes metrics + quality.

--- a/examples/ngspice_fixtures/tasks/T-105_e2e_orchestrator.md
+++ b/examples/ngspice_fixtures/tasks/T-105_e2e_orchestrator.md
@@ -1,0 +1,12 @@
+# T-105 — Implement E2E orchestrator
+
+## Objective
+Create one command pipeline for fixtures->normalize->query smoke->analyze.
+
+## Scope
+- `scripts/e2e.py`
+- Stage-wise execution and fail-fast error reporting.
+
+## DoD
+- Running e2e command generates all expected outputs.
+- Prints concise success/failure summary with artifact paths.

--- a/examples/ngspice_fixtures/tasks/T-106_fix_raw_normalization_path.md
+++ b/examples/ngspice_fixtures/tasks/T-106_fix_raw_normalization_path.md
@@ -1,0 +1,14 @@
+# T-106 — Fix raw normalization mismatch and validate E2E
+
+## Objective
+Make current E2E pipeline pass by fixing fixture RAW generation vs normalizer format handling.
+
+## Scope
+- Update fixtures and/or normalizer to support actual produced RAW format.
+- Validate complete E2E pipeline.
+- Ensure commands use `.venv/` under repo root.
+
+## DoD
+- E2E command succeeds (exit 0) from repo root.
+- Output artifacts generated across all 3 stages.
+- README includes local venv bootstrap + run instructions.

--- a/examples/ngspice_fixtures/tasks/T-107_waveform_plotter_png.md
+++ b/examples/ngspice_fixtures/tasks/T-107_waveform_plotter_png.md
@@ -1,0 +1,15 @@
+# T-107 — Implement waveform plotter and validate PNG output
+
+## Objective
+Build `tools/plot_waveforms.py` to render waveform plots from normalized HDF5 and save PNG files.
+
+## Scope
+- CLI args: input h5, signal(s), output path, title/style options.
+- Use matplotlib.
+- Handle missing signals with clear errors.
+- Add minimal tests or smoke validation script.
+
+## DoD
+- Generates PNG for at least two fixture cases.
+- README includes example commands.
+- Repo-local `.venv` install notes remain valid.

--- a/libs/exp_010_hello_xyce/tb_ngspice.asdl
+++ b/libs/exp_010_hello_xyce/tb_ngspice.asdl
@@ -1,0 +1,26 @@
+top: tb
+
+imports:
+  gf: gf180mcu.asdl
+  inv: ./inv.asdl
+  ana: analoglib.asdl
+  sim: simulation.ngspice.asdl
+
+modules:
+  tb:
+    instances:
+      dut: inv.inv
+      vsrc_vdd: ana.vdc dc=3.3
+      vsrc_vss: ana.vdc dc=0
+      vsrc_in: ana.vdc dc=0
+
+      models: gf.models
+      dc1: sim.dc vsrc=vsrc_in from=0 to=3.3 step=0.01
+      save_v: sim.save signals='all'
+
+    nets:
+      vin: [vsrc_in.p, dut.in]
+      vout: [dut.out]
+      vdd: [vsrc_vdd.p, dut.vdd]
+      vss: [vsrc_vss.p, vsrc_<vdd|in>.n, dut.vss]
+      '0': [vsrc_vss.n]

--- a/libs/exp_010_hello_xyce/tb_ngspice.log.json
+++ b/libs/exp_010_hello_xyce/tb_ngspice.log.json
@@ -1,0 +1,29 @@
+{
+  "diagnostic_count": 0,
+  "diagnostic_severity_counts": {
+    "error": 0,
+    "fatal": 0,
+    "info": 0,
+    "warning": 0
+  },
+  "diagnostics": [],
+  "emission_name_map": [
+    {
+      "base_name": "tb",
+      "emitted_name": "tb",
+      "file_id": "/home/node/.openclaw/workspace/asdl_ecosystem_playground/libs/exp_010_hello_xyce/tb_ngspice.asdl",
+      "renamed": false,
+      "symbol": "tb"
+    },
+    {
+      "base_name": "inv",
+      "emitted_name": "inv",
+      "file_id": "/home/node/.openclaw/workspace/asdl_ecosystem_playground/libs/exp_010_hello_xyce/inv.asdl",
+      "renamed": false,
+      "symbol": "inv"
+    }
+  ],
+  "view_bindings": [],
+  "warning_count": 0,
+  "warnings": []
+}

--- a/libs_common/analoglib.asdl
+++ b/libs_common/analoglib.asdl
@@ -40,6 +40,8 @@ devices:
       phase: 0
 
     backends:
+      sim.ngspice:
+        template: 'V_{name} {ports} SIN ({offset} {amp} {freq} {td} {theta} {phase})'
       sim.xyce:
         template: 'V_{name} {ports} SIN ({offset} {amp} {freq} {td} {theta} {phase})'
 

--- a/libs_common/simulation.ngspice.asdl
+++ b/libs_common/simulation.ngspice.asdl
@@ -1,0 +1,48 @@
+devices:
+  dc:
+    parameters:
+      vsrc: ''
+      from: 0
+      to: 1
+      step: 0.01
+    backends:
+      sim.ngspice:
+        template: |
+          .DC V_{vsrc} {from} {to} {step}
+
+  ac:
+    parameters:
+      sweep_type: DEC
+      points: 100
+      start_freq: 1
+      end_freq: 1e9
+    backends:
+      sim.ngspice:
+        template: |
+          .AC {sweep_type} {points} {start_freq} {end_freq}
+
+  tran:
+    parameters:
+      step: 1e-9
+      stop: 1e-6
+      start: 0
+    backends:
+      sim.ngspice:
+        template: |
+          .TRAN {step} {stop} {start}
+
+  param:
+    parameters:
+      value: ''
+    backends:
+      sim.ngspice:
+        template: |
+          .PARAM {name}={value}
+
+  save:
+    parameters:
+      signals: 'all'
+    backends:
+      sim.ngspice:
+        template: |
+          .SAVE {signals}


### PR DESCRIPTION
## Summary\n- add ngspice RAW->HDF5 normalizer, query tool, analyzer adapter, and waveform PNG plotter\n- add fixture netlists and e2e scripts under examples/ngspice_fixtures\n- add ngspice simulation primitives and tb variant for exp_010\n\n## Validation\n- python3 -m py_compile analysis/tools/ngspice/*.py\n- fixture plotting + normalization flow validated in prototype repo and ported here